### PR TITLE
Add another s3 image url into grade parameters endpoint

### DIFF
--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1813,11 +1813,12 @@ class GradeParametersFromFileNameView(APIView):
                     certificate_id = regex_match[2]
                     orientation = regex_match[3]
                     image_type = regex_match[4]
-                    image_url = f"https://pokemon-statics.s3.amazonaws.com/media/{orientation}/{certificate_id}_{orientation}.jpg"
+                    image_url = f"https://ags-cvat-storage.s3.us-west-2.amazonaws.com/{order_id}-%2B{certificate_id}-%2B{orientation}_laser.png"
+                    image_url_legacy = f"https://pokemon-statics.s3.amazonaws.com/media/{orientation}/{certificate_id}_{orientation}.jpg"
                     labeled_shapes = LabeledShape.objects.select_related('label').filter(job_id=job.id, frame=image.frame)
                     objects = [{"points": labeled_shape.points, "label": labeled_shape.label.name, "shape": labeled_shape.type} for labeled_shape in labeled_shapes]
                     payload = {"filename": filename, "objects": objects, "image": {"width": width, "height": height}}
-                    result = {"payload": payload, "order_id": order_id, "certificate_id": certificate_id, "orientation": orientation, "image_type": image_type, "image_path": image_path, "image_url": image_url}
+                    result = {"payload": payload, "order_id": order_id, "certificate_id": certificate_id, "orientation": orientation, "image_type": image_type, "image_path": image_path, "image_url": image_url, "image_url_legacy": image_url_legacy}
                     results.append(result)
                 
                 return Response(results)


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
